### PR TITLE
#41 Make sure region value is always string

### DIFF
--- a/Model/Data/VippsCustomerAddress.php
+++ b/Model/Data/VippsCustomerAddress.php
@@ -176,7 +176,7 @@ class VippsCustomerAddress extends AbstractExtensibleObject implements VippsCust
      */
     public function getRegion()
     {
-        return $this->_get('region');
+        return (string) $this->_get('region');
     }
 
     /**


### PR DESCRIPTION
The "region" field in "vipps_customer_address" table is defined (see db_schema.xml) as nullable field. Same time loaded from database the region value is returned by getRegion() function and result is used then in string-related functions (like, preg_replace(), strcasecmp()) where argument type is specified as string and null value causes TypeError like this: 
TypeError: strcasecmp(): Argument #1 ($string1) must be of type string, null given in [...] vendor/vipps/module-login/Model/VippsAddressManagement.php:385